### PR TITLE
Corrected PluginPackedPath + PluginUnpackedPath

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,8 +26,8 @@ jobs:
       ProductVersion: Studio16
       VersionNumber: 16
       VisualStudioEdition: 'Microsoft Visual Studio 2019'
-      PluginPackedPath : '%AppData%\Roaming\SDL\SDL Trados Studio\16\Plugins\Packages\'
-      PluginUnpackedPath: '%AppData%\Roaming\SDL\SDL Trados Studio\16\Plugins\Unpacked\'
+      PluginPackedPath : '%AppData%\SDL\SDL Trados Studio\16\Plugins\Packages\'
+      PluginUnpackedPath: '%AppData%\SDL\SDL Trados Studio\16\Plugins\Unpacked\'
       InstallationFolder: 'C:\Program Files\SDL\SDL Trados Studio\Studio16\'
       DefaultProjectsFolder: 'C:\Users\UserName\Documents\Studio 2021\Projects'
       StudioDocumentsFolderName: 'Studio 2021'

--- a/Plugins/TradosStudioDocsPlugin/TradosStudioDocsPlugin/VariableInlineRule.cs
+++ b/Plugins/TradosStudioDocsPlugin/TradosStudioDocsPlugin/VariableInlineRule.cs
@@ -43,8 +43,8 @@ namespace TradosStudioDocsPlugin
                 { "ProductVersion", "Studio16" },
                 { "VersionNumber", "16" },
                 { "VisualStudioEdition", "Microsoft Visual Studio 2019" },
-                { "PluginPackedPath", "%AppData%\\Roaming\\SDL\\SDL Trados Studio\\16\\Plugins\\Packages\\" },
-                { "PluginUnpackedPath", "%AppData%\\Roaming\\SDL\\SDL Trados Studio\\16\\Plugins\\Unpacked\\" },
+                { "PluginPackedPath", "%AppData%\\SDL\\SDL Trados Studio\\16\\Plugins\\Packages\\" },
+                { "PluginUnpackedPath", "%AppData%\\SDL\\SDL Trados Studio\\16\\Plugins\\Unpacked\\" },
                 { "InstallationFolder", "C:\\Program Files\\SDL\\SDL Trados Studio\\Studio16" },
                 { "AppSigningEmail", "app-signing@sdl.com" }
             };


### PR DESCRIPTION
Hi there!

As of [docs.microsoft.com](https://docs.microsoft.com/en-us/windows/deployment/usmt/usmt-recognized-environment-variables#variables-that-are-recognized-only-in-the-user-context), the `%AppData%` environment variable points to the path `C:\Users\username\AppData\Roaming`, which already contains the "Roaming" folder. You can also validate this by running `echo %AppData%` in cmd.exe.

I have corrected both "PluginPackedPath" and "PluginUnpackedPath", so that the expanded path resolves to a valid location.